### PR TITLE
Fix published date on the-joy-of-building post

### DIFF
--- a/_posts/2026-06-13-the-joy-of-building.md
+++ b/_posts/2026-06-13-the-joy-of-building.md
@@ -1,6 +1,6 @@
 ---
 title: "AI and the Joy of Building"
-date: 2026-03-11
+date: 2026-06-13
 ---
 
 # I just want to bulid cool things


### PR DESCRIPTION
The post front matter had `date: 2026-03-11`; corrected to `2026-06-13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)